### PR TITLE
feature/RHP_231-seasons-need-to-be-ordered-by-number-instead-of-date

### DIFF
--- a/app/api/seasonsService.js
+++ b/app/api/seasonsService.js
@@ -42,7 +42,7 @@
       return new Promise((resolve, reject) => {
         Season
           .find()
-          .sort('-startDate')
+          .sort('-seasonNumber')
           .exec((err, seasons) => {
             if (err) {
               LOG.error(err.stack);


### PR DESCRIPTION
Sort seasons appropriately